### PR TITLE
changes on docker-js-eval image, more formatting tests (WIP)

### DIFF
--- a/src/plugins/js-eval/__tests__/jsEvalPlugin-test.js
+++ b/src/plugins/js-eval/__tests__/jsEvalPlugin-test.js
@@ -1,8 +1,8 @@
 const jsEval = require('../jsEvalPlugin');
 
 describe('jsEvalPlugin', () => {
-  it(`works`, () => {
-    jsEval({
+  it(`works`, async () => {
+    await jsEval({
       message: 'n> 2+2',
       respond: output => {
         expect(output).toEqual('(okay) 4');
@@ -10,8 +10,8 @@ describe('jsEvalPlugin', () => {
     });
   });
 
-  it(`errors when it should`, () => {
-    jsEval({
+  it(`errors when it should`, async () => {
+    await jsEval({
       message: 'n> 2++2',
       respond: output => {
         expect(output).toEqual(`(error) ecmabot.js:1
@@ -22,7 +22,7 @@ ReferenceError: Invalid left-hand side expression in postfix operation`);
       }
     });
 
-    jsEval({
+    await jsEval({
       message: 'n> throw 2',
       respond: output => {
         expect(output).toEqual('(error) 2');
@@ -30,26 +30,26 @@ ReferenceError: Invalid left-hand side expression in postfix operation`);
     });
   });
 
-  it(`times out`, () => {
-    jsEval({
-      message: 'n> setTimeout(() => {}, 50000)',
+  it(`times out`, async () => {
+    await jsEval({
+      message: 'n> setTimeout(() => console.log(2), 15000); 1',
       respond: output => {
-        expect(output).toEqual('(error) Timeout');
+        expect(output).toEqual('(timeout) 1');
       }
     });
   });
 
-  it(`exposes node core modules`, () => {
-    jsEval({
-      message: `n> fs.readdirSync('.')`,
+  it(`exposes node core modules`, async () => {
+    await jsEval({
+      message: `n> [fs.readdirSync('.'), child_process.execSync('ls')+'']`,
       respond: output => {
-        expect(output).toEqual(`(okay) []`);
+        expect(output).toEqual(`(okay) [ [], '' ]`);
       }
     });
   });
 
-  it(`replies to user`, () => {
-    jsEval({
+  it(`replies to user`, async () => {
+    await jsEval({
       message: `n>'ok'`,
       mentionUser: 'jay',
       respond: output => {

--- a/src/plugins/js-eval/evalUtils.js
+++ b/src/plugins/js-eval/evalUtils.js
@@ -1,8 +1,0 @@
-const crypto = require('crypto');
-
-const names = {
-  make: () => `jseval-${crypto.randomBytes(8).toString('hex')}`,
-  test: (str) => /^jseval-[a-f0-9]+$/i.test(str),
-};
-
-exports.names = names;

--- a/src/plugins/js-eval/init.js
+++ b/src/plugins/js-eval/init.js
@@ -1,41 +1,10 @@
 const { exec } = require('child_process');
-const evalUtils = require('./evalUtils');
-
-const tryParse = (json) => {
-  try {
-    return JSON.parse(json);
-  } catch (e) {
-    return null;
-  }
-};
 
 async function initJsEval() {
   // Kill all docker containers created with "--name jseval-{some hex string}"
-  exec(`docker ps --format '{{ json . }}'`, { encoding: 'utf-8'}, (err, stdout = '') => {
-    const containers = stdout.split(/[\r\n]+/)
-      .map(x => x.trim())
-      .filter(Boolean)
-      .map(tryParse)
-      .filter(Boolean);
+  exec(`docker rm -f $(docker ps -qf name=jseval-) 2>/dev/null`, (err, stdout = '') => {
 
-    const evalContainers = containers.filter(x => evalUtils.names.test(x.Names));
-    if (!evalContainers.length) {
-      return;
-    }
-
-    console.log(`There were ${evalContainers.length} containers still running when the bot started. Killing.`);
-    evalContainers.forEach((cont) => {
-      exec(`docker kill "${cont.ID}"`, { encoding: 'utf-8' }, (killErr, killStdout) => {
-        if (killErr) {
-          console.error(`Failed to kill container`, cont);
-          console.error(' ', killErr.message);
-          console.error(killStdout.trim() + '\n\n');
-          return;
-        }
-
-        console.error(`Killed container ${cont.ID} / ${cont.Names}`);
-      });
-    });
+    console.log(`There were ${stdout.trim().split('\n').length} containers still running when the bot started. Killing them softly.`);
   });
 }
 

--- a/src/plugins/js-eval/jsEvalPlugin.js
+++ b/src/plugins/js-eval/jsEvalPlugin.js
@@ -1,15 +1,15 @@
 const { exec } = require('child_process');
-const evalUtils = require('./evalUtils');
+const crypto = require('crypto');
 
 const children = new Set();
 
-const jsEvalPlugin = async ({ mentionUser, respond, message, selfConfig, log }) => {
+const jsEvalPlugin = async ({ mentionUser, respond, message, selfConfig = { timer: 5000 }, log }) => {
   if (!message.startsWith('n>')) return;
   const code = message.slice(2);
-  const childId = evalUtils.names.make();
 
   let didRespond = false;
   let child;
+  const childId = `jseval-${crypto.randomBytes(8).toString('hex')}`;
 
   const done = (err, stdout = '') => {
     if (didRespond) {
@@ -18,31 +18,30 @@ const jsEvalPlugin = async ({ mentionUser, respond, message, selfConfig, log }) 
     didRespond = true;
     children.delete(child);
 
-    const msg = err && err.killed ? 'Timeout' : stdout.trim();
-    const prefix = mentionUser ? `${mentionUser}, ` : err ? '(error) ' : '(okay) ';
-    respond(prefix + msg);
+    const prefix = mentionUser ? `${mentionUser}, ` : err ? (err.killed ? '(timeout) ' : '(error) ') : '(okay) ';
+    respond(prefix + stdout.trim());
   };
 
   const timer = setTimeout(() => {
     done({ killed: true }, '');
     child.kill();
 
-    exec(`docker kill "${childId}"`, { encoding: 'utf-8'}, (err, stdout = '', stderr = '') => {
+    exec(`docker kill "${childId}"`, { encoding: 'utf-8' }, (err, stdout = '', stderr = '') => {
       const ignore = !err || /No such container/.test(`${stdout}\0${stderr}`);
       if (!ignore) {
         log(`Failed to kill docker container ${name}\n${stdout}\n${stderr}`);
       }
     });
-  }, selfConfig.timer || 5000);
+  }, 1.5 * selfConfig.timer || 5000);
 
-  child = exec(`docker run --rm -i --net=none --name=${childId} devsnek/js-eval`, { encoding: 'utf-8'}, (err, stdout = '') => {
+  child = exec(`docker run --rm -i --net=none --name=${childId} -eJSEVAL_ENV=node-cjs devsnek/js-eval`, { encoding: 'utf-8', timeout: selfConfig.timer || 5000 }, (err, stdout = '') => {
     clearTimeout(timer);
     done(err, stdout);
   });
 
   children.add(child);
 
-  child.stdin.write(JSON.stringify({ environment: 'node-cjs', code }));
+  child.stdin.write(code);
   child.stdin.end();
 };
 

--- a/src/utils/__tests__/__snapshots__/getConfig-test.js.snap
+++ b/src/utils/__tests__/__snapshots__/getConfig-test.js.snap
@@ -16,7 +16,11 @@ Object {
   },
   "nick": "jellobot",
   "password": null,
-  "plugins": Object {},
+  "plugins": Object {
+    "jsEval": Object {
+      "timeout": 5000,
+    },
+  },
   "server": "chat.freenode.net",
   "verbose": false,
 }


### PR DESCRIPTION
There are formatting issues, fixed in https://github.com/devsnek/docker-js-eval/pull/6 (waiting for merge)

basically currently we get
```
13:14 <qswz> n> [fs.readdirSync('.'), require('child_process').execSync('ls')+'']
13:14 <jellobot1> (okay) [   [],   '' ]
```
this is due to line returns in current devsnek/js-eval
```
Expected value to equal:
  "(okay) [ [], '' ]"
Received:
  "(okay) [
  [],
  ''
]"
```

(note: child_process should be avail in global in current devsnek/js-eval image)

The tests pass with my local build of devsnek/js-eval