### PR TITLE
js-eval: update docker image, add node -p

### DIFF
--- a/src/plugins/js-eval/Dockerfile
+++ b/src/plugins/js-eval/Dockerfile
@@ -1,51 +1,11 @@
-FROM debian:9-slim
+FROM node:slim
+RUN npm i --prefix /run date-fns airbnb-js-shims
 
-ARG NODE_VERSION
-ENV NODE_VERSION $NODE_VERSION
-
-# same than https://github.com/nodejs/docker-node/blob/master/11/stretch-slim/Dockerfile, gpg keys listed at https://github.com/nodejs/node#release-team
-RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
-  && case "${dpkgArch##*-}" in \
-  amd64) ARCH='x64';; \
-  ppc64el) ARCH='ppc64le';; \
-  s390x) ARCH='s390x';; \
-  arm64) ARCH='arm64';; \
-  armhf) ARCH='armv7l';; \
-  i386) ARCH='x86';; \
-  *) echo "unsupported architecture"; exit 1 ;; \
-  esac \
-  && set -ex \
-  && apt-get update && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && for key in \
-  94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-  FD3A5288F042B6850C66B31F09FE44734EB7990E \
-  71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-  DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-  C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-  B9AE9905FFD7803F25714661B63B535A4C206CA9 \
-  77984A986EBC2AA786BC0F66B01FBB92821C587A \
-  8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
-  4ED778F539E3634C779C87C6D7062848A1AB005C \
-  A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
-  ; do \
-  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-  gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-  gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
-  done \
-  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
-  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
-  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
-  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
-  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
-  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && apt-get purge -y --auto-remove gnupg dirmngr xz-utils \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
-
+FROM debian:stretch-slim
 RUN useradd node && mkdir -p /home/node && chown -R node:node /home/node
 WORKDIR /home/node
+COPY --from=0 /run /run
+COPY --from=0 /usr/local/bin/node /usr/local/bin/node
 COPY --chown=node run.js /run/
-RUN npm i --prefix /run date-fns airbnb-js-shims
 USER node
-
-CMD ["node", "/run/run.js"]
+CMD ["node", "--no-warnings", "/run/run.js"]

--- a/src/plugins/js-eval/__tests__/jsEvalPlugin-test.js
+++ b/src/plugins/js-eval/__tests__/jsEvalPlugin-test.js
@@ -17,7 +17,7 @@ describe('jsEvalPlugin', () => {
     await jsEval({
       message: 'n> setTimeout(() => console.log(2), 1000); 1',
       respond: output => {
-        expect(output).toEqual('(okay) 12\n');
+        expect(output).toEqual('(okay) 12');
       }
     });
   });
@@ -124,6 +124,15 @@ describe('jsEvalPlugin', () => {
       message: `b> typeof Object.fromEntries`,
       respond: output => {
         expect(output).toEqual(`(okay) 'function'`);
+      }
+    });
+  });
+
+  it(`handles empty input`, async () => {
+    await jsEval({
+      message: `n>  `,
+      respond: output => {
+        expect(output).toEqual(`(okay) undefined`);
       }
     });
   });

--- a/src/plugins/js-eval/init
+++ b/src/plugins/js-eval/init
@@ -7,13 +7,6 @@ if (( n_killed )); then
   echo "Killed $n_killed js-eval containers."
 fi
 
-if [[ ! $NODE_VERSION ]]; then
-  NODE_VERSION=$(curl -sSL https://nodejs.org/dist | awk '/>v/{ split($2, a, "[<>]"); sub("/","",a[2]); print a[2] }' | sort -V | tail -n1)
-fi
-
-NODE_VERSION=${NODE_VERSION#v*} # trim v prefix, if any
-
 dir=$(dirname $0)
-docker build -t brigand/js-eval --build-arg NODE_VERSION=$NODE_VERSION $dir -f $dir/Dockerfile
-
+docker build -t brigand/js-eval $dir -f $dir/Dockerfile
 docker images brigand/js-eval:latest

--- a/src/plugins/js-eval/jsEval.js
+++ b/src/plugins/js-eval/jsEval.js
@@ -10,8 +10,7 @@ const crypto = require('crypto');
  */
 const jsEval = (code, environment = 'node-cjs', timeout = 5000, cmd = []) => new Promise((resolve, reject) => {
   const name = `jseval-${crypto.randomBytes(8).toString('hex')}`;
-  const args = ['run', '--rm', '-i', `--name=${name}`, `--net=none`, `-eJSEVAL_ENV=${environment}`, `-eJSEVAL_TIMEOUT=${timeout}`, 'brigand/js-eval', ...cmd];
-
+  const args = ['run', '-i', '--rm', `--name=${name}`, `--net=none`, `-eJSEVAL_ENV=${environment}`, `-eJSEVAL_TIMEOUT=${timeout}`, 'brigand/js-eval', ...cmd];
   let data = '';
   const timer = setTimeout(() => {
     try {
@@ -23,6 +22,7 @@ const jsEval = (code, environment = 'node-cjs', timeout = 5000, cmd = []) => new
   }, timeout + 10);
 
   const proc = cp.spawn('docker', args);
+
   proc.stdin.write(code);
   proc.stdin.end();
 
@@ -40,7 +40,7 @@ const jsEval = (code, environment = 'node-cjs', timeout = 5000, cmd = []) => new
     if (status !== 0) {
       reject(new Error(data));
     } else {
-      resolve(data);
+      resolve(data.trim());
     }
   });
 });

--- a/src/plugins/js-eval/jsEvalPlugin.js
+++ b/src/plugins/js-eval/jsEvalPlugin.js
@@ -11,7 +11,7 @@ const babelTransform = code => new Promise((res, rej) => babel.transform(
 const helpMsg = `n> node-cjs stable, h> node-cjs harmony, b> babel (stage1+), s> [script](nodejs.org/api/vm.html#vm_class_vm_script), m> [module](nodejs.org/api/vm.html#vm_class_vm_sourcetextmodule)`;
 
 // default jseval run command
-const CMD = ['node', '/run/run.js'];
+const CMD = ['node', '--no-warnings', '/run/run.js'];
 const CMD_SHIMS = ['node', '-r', '/run/node_modules/airbnb-js-shims/target/es2019', '/run/run.js'];
 const CMD_HARMONY = ['node', '--harmony-bigint', '--harmony-class-fields', '--harmony-private-fields', '--harmony-static-fields', '--harmony-public-fields', '--harmony-do-expressions', '--harmony-await-optimization', '--experimental-vm-modules', '--experimental-modules', '--no-warnings', '/run/run.js'];
 


### PR DESCRIPTION
- Simplify Dockerfile
- Add a p> command reusing simply `node -p` option, I thought I would be able to pass `--experimental-repl-await` intially, but no :(, but still think that command doesn't hurt