### PR TITLE
Don't forget stderr

### DIFF
--- a/src/plugins/js-eval/__tests__/jsEvalPlugin-test.js
+++ b/src/plugins/js-eval/__tests__/jsEvalPlugin-test.js
@@ -24,6 +24,9 @@ describe('jsEvalPlugin', () => {
 
     const output2 = await testEval('n> setTimeout(() => console.log(2), 1000); 1');
     expect(output2).toEqual('(okay) 12');
+
+    const output3 = await testEval('n> console.warn("test")');
+    expect(output3).toEqual(`(okay) test\nundefined`);
   });
 
   it(`errors when it should`, async () => {

--- a/src/plugins/js-eval/jsEval.js
+++ b/src/plugins/js-eval/jsEval.js
@@ -30,6 +30,10 @@ const jsEval = (code, environment = 'node-cjs', timeout = 5000, cmd = []) => new
     data += chunk;
   });
 
+  proc.stderr.on('data', (chunk) => {
+    data += chunk;
+  });
+
   proc.on('error', (e) => {
     clearTimeout(timer);
     reject(e);

--- a/src/plugins/js-eval/jsEvalPlugin.js
+++ b/src/plugins/js-eval/jsEvalPlugin.js
@@ -7,7 +7,7 @@ const helpMsg = `n> node stable, h> node harmony, b> babel, s> node vm.Script, m
 
 // default jseval run command
 const CMD = ['node', '--no-warnings', '/run/run.js'];
-const CMD_SHIMS = ['node', '-r', '/run/node_modules/airbnb-js-shims/target/es2019', '/run/run.js'];
+const CMD_SHIMS = ['node', '-r', '/run/node_modules/airbnb-js-shims/target/es2019', '--no-warnings', '/run/run.js'];
 const CMD_HARMONY = ['node', '--harmony', '--experimental-vm-modules', '--experimental-modules', '--no-warnings', '/run/run.js'];
 
 const jsEvalPlugin = async ({ mentionUser, respond, message, selfConfig = {} }) => {


### PR DESCRIPTION
I added a --no-warning for babel because I surprisingly suddenly had this:
```
  ● jsEvalPlugin › can run babel with b>

    expect(received).toEqual(expected)

    Expected value to equal:
      "(okay) 3n"
    Received:
      "(okay) (node:1) ExperimentalWarning: Readable[Symbol.asyncIterator] is an experimental feature. This feature could change at any time
    3n"
```

tests pass with --no-warning added