### PR TITLE
js-eval build on latest release

### DIFF
--- a/src/plugins/js-eval/Dockerfile
+++ b/src/plugins/js-eval/Dockerfile
@@ -1,9 +1,18 @@
-FROM node:slim
-RUN npm i --prefix /run airbnb-js-shims full-icu acorn nearley
-# acorn nearley are needed by engine262
+FROM debian:10-slim
+
+RUN apt-get update && apt-get install -y xz-utils ca-certificates curl --no-install-recommends 
+RUN node_version=$(curl -sSL https://nodejs.org/download/release | awk '/>v/{ split($2, a, "[<>]"); sub("/","",a[2]); print a[2] }' | sort -V | tail -n1) \
+  && curl -fsSLO --compressed "https://nodejs.org/download/release/$node_version/node-$node_version-linux-x64.tar.xz" \
+  && tar -xJf "node-$node_version-linux-x64.tar.xz" -C /usr/local --strip-components=1 --no-same-owner
+RUN node --version
+
+# install shims, and acorn+nearley needed by engine262
+RUN npm i --prefix /run airbnb-js-shims acorn nearley
 COPY vendor/engine262.js /run/node_modules/engine262.js
 
-FROM debian:stretch-slim
+
+FROM debian:10-slim
+
 RUN useradd node && mkdir -p /home/node && chown -R node:node /home/node
 WORKDIR /home/node
 COPY --from=0 /run /run

--- a/src/plugins/js-eval/Dockerfile
+++ b/src/plugins/js-eval/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:10-slim
 
-RUN apt-get update && apt-get install -y xz-utils ca-certificates curl --no-install-recommends 
-RUN node_version=$(curl -sSL https://nodejs.org/download/release | awk '/>v/{ split($2, a, "[<>]"); sub("/","",a[2]); print a[2] }' | sort -V | tail -n1) \
+RUN apt-get update && apt-get install -y xz-utils ca-certificates curl --no-install-recommends
+RUN node_version=$(curl -sSL https://nodejs.org/download/release/ | awk '/>v/{ split($2, a, "[<>]"); sub("/","",a[2]); print a[2] }' | sort -V | tail -n1) \
   && curl -fsSLO --compressed "https://nodejs.org/download/release/$node_version/node-$node_version-linux-x64.tar.xz" \
   && tar -xJf "node-$node_version-linux-x64.tar.xz" -C /usr/local --strip-components=1 --no-same-owner
 RUN node --version

--- a/src/plugins/js-eval/__tests__/jsEvalPlugin-test.js
+++ b/src/plugins/js-eval/__tests__/jsEvalPlugin-test.js
@@ -32,7 +32,7 @@ describe('jsEvalPlugin', () => {
   it(`errors when it should`, async () => {
     const output = await testEval('n> 2++2');
     expect(output).toEqual(
-      `(fail) ReferenceError: Invalid left-hand side expression in postfix operation`,
+      `(fail) SyntaxError: Invalid left-hand side expression in postfix operation`,
     );
 
     const output2 = await testEval('n> throw 2');

--- a/src/plugins/js-eval/__tests__/jsEvalPlugin-test.js
+++ b/src/plugins/js-eval/__tests__/jsEvalPlugin-test.js
@@ -44,7 +44,7 @@ describe('jsEvalPlugin', () => {
 
   it(`times out but return temporary result`, async () => {
     const output = await testEval('n> setTimeout(() => console.log(2), 10000); 1', {
-      selfConfig: { timer: 1000 },
+      selfConfig: { timer: 2000 },
     });
     expect(output).toEqual('(timeout) 1');
   });


### PR DESCRIPTION
docker-node just published a v13 https://github.com/nodejs/docker-node/tree/master/13

but with this PR we could also do without docker-node, directly downloading a release

pros: one less intermediary, and no need to `docker pull node:slim` for getting latest version