### PR TITLE
MDN Plugin: updated summary extraction

### DIFF
--- a/src/plugins/mdn/mdnPlugin.js
+++ b/src/plugins/mdn/mdnPlugin.js
@@ -59,8 +59,11 @@ function extractFromHtml(html) {
   // Object#__proto__: There are .notecard elements we don't want to match, which contain <p> elements,
   // followed by a <p> we do want to match.
   // Command: !mdn object.__proto__
-  $('.notecard').remove();
-  const text = findFirst($article, '.seoSummary', 'p')
+  const text = findFirst(
+    $article,
+    '.seoSummary',
+    ':not(.notecard) > p:not(.notecard)',
+  )
     .text()
     .replace(/\s+/g, ' ')
     .trim();

--- a/src/plugins/mdn/mdnPlugin.js
+++ b/src/plugins/mdn/mdnPlugin.js
@@ -6,7 +6,8 @@ function slugify(words) {
   return words
     .map((x) => x.trim().toLowerCase())
     .join('-')
-    .replace(/[^a-zA-Z0-9_.]+/g, '-');
+    .replace(/[^a-zA-Z0-9_.]+/g, '-')
+    .replace(/^-|-$/g, '');
 }
 
 class HtmlParseError extends Error {}

--- a/src/plugins/mdn/mdnPlugin.js
+++ b/src/plugins/mdn/mdnPlugin.js
@@ -6,8 +6,7 @@ function slugify(words) {
   return words
     .map((x) => x.trim().toLowerCase())
     .join('-')
-    .replace(/[^a-zA-Z0-9]+/g, '-')
-    .replace(/[^a-zA-Z0-9]+/g, '-');
+    .replace(/[^a-zA-Z0-9_.]+/g, '-');
 }
 
 class HtmlParseError extends Error {}


### PR DESCRIPTION
Comment on line 52 shows the variants I'm seeing in the MDN HTML.

On further analysis, it seems the issue with `!mdn __proto__` was that it got converted to `mdn.io/-proto-` (presumably like googling "mdn -proto"), but both `mdn.io/proto` and `mdn.io/__proto__` end up at the right page.


> Me: !mdn array.map
> Bot: Array.prototype.map() - The map() method creates a new array populated with the results of calling a provided function on every element in the calling array. https://mdn.io/array.map

> Me: !mdn proto
> Bot: Object.prototype.__proto__ - The __proto__ property of Object.prototype is an accessor property (a getter function and a setter function) that exposes the internal [[Prototype]] (either an object or null) of the object through which it is accessed. https://mdn.io/proto

> Me: !mdn document.write
> Bot: Document.write() - The Document.write() method writes a string of text to a document stream opened by document.open(). https://mdn.io/document.write
