### PR TITLE
Support Multiple Servers

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -11,153 +11,175 @@ const changeNick = require('./utils/changeNick');
 
 const logBotPrefix = chalk.black.bgYellow('BOT');
 
-let config = readAndProcessConfig();
+let globalConfig = readAndProcessConfig();
 
 init().catch((e) => {
   console.error(`init failed. This is potentially unsafe, but we'll continue.`);
   console.error(e);
 });
 
-const client = new irc.Client(config.server, config.nick, config.ircClientConfig);
-client.currentNick = config.nick;
-client.currentPrefix = '';
+const clients = globalConfig.servers.map((server, index) => {
+  const client = new irc.Client(server.server, server.nick, server.ircClientConfig);
+
+  client.clientIndex = index;
+  client.clientHost = server.server;
+  client.currentNick = server.nick;
+  client.currentPrefix = '';
+  client.serverConfig = server;
+
+  return client;
+});
 
 function updateConfig() {
   const newConfig = readAndProcessConfig();
-  if (!config) {
-    config = newConfig;
+  if (!globalConfig) {
+    globalConfig = newConfig;
     return;
   }
 
-  // Cache these before we update the 'config' variable
-  const oldChan = config.channels;
-  const newChan = newConfig.channels;
-  const oldNick = config.nick;
-  const newNick = newConfig.nick;
-
+  const oldConfig = globalConfig;
   // Replace the config, which is passed around
-  config = newConfig;
+  globalConfig = newConfig;
 
-  // join channels
-  for (const chan of newChan) {
-    if (!oldChan.find((x) => x.name === chan.name)) {
-      client.join(chan.name);
-    }
-  }
-  for (const chan of oldChan) {
-    if (!newChan.find((x) => x.name === chan.name)) {
-      client.part(chan.name);
-    }
-  }
+  for (const server of newConfig.servers) {
+    const prevServer = oldConfig.servers.find((old) => old.server === server.server);
+    const client = clients.find((client) => client.clientHost === server.server);
+    if (prevServer && client) {
+      client.serverConfig = server;
 
-  if (oldNick !== newNick) {
-    changeNick(client, config.nick, false);
+      // Cache these before we update the 'config' variable
+      const oldChan = prevServer.channels;
+      const newChan = server.channels;
+      const oldNick = prevServer.nick;
+      const newNick = server.nick;
+
+      // join channels
+      for (const chan of newChan) {
+        if (!oldChan.find((x) => x.name === chan.name)) {
+          client.join(chan.name);
+        }
+      }
+      for (const chan of oldChan) {
+        if (!newChan.find((x) => x.name === chan.name)) {
+          client.part(chan.name);
+        }
+      }
+
+      if (oldNick !== newNick) {
+        changeNick(client, newNick, false);
+      }
+    }
   }
 }
 
 setInterval(updateConfig, 3000);
 
-// mutable list of recent messages per channel
-// newest messages first
-const logs = {};
+clients.forEach((client) => {
+  /* eslint-disable no-param-reassign */
 
-let lastProcessMessageFail = 0;
+  const config = client.serverConfig;
 
-client.addListener('message', (from, to, message) => {
-  if (from === config.nick) return;
+  // mutable per-server list of recent per-channel messages
+  // newest messages first
+  let lastProcessMessageFail = 0;
+  const logs = {};
 
-  maybeClearCache(/processMessage/);
+  client.addListener('message', (from, to, message) => {
+    if (from === config.nick) return;
 
-  let messageObj;
-  try {
-    // eslint-disable-next-line global-require
-    const processMessage = require('./processMessage');
-    messageObj = processMessage(client, config, logs, from, to, message);
-  } catch (e) {
-    const isRoom = /^#/.test(to);
-    if (Date.now() > lastProcessMessageFail + 1000 * 60 * 60) {
-      lastProcessMessageFail = Date.now();
-      client.say(isRoom ? to : from, `Internal error while processing the message`);
-    }
-    return;
-  }
+    maybeClearCache(/processMessage/);
 
-  plugins.run(messageObj);
-});
-
-client.addListener('join', (channel, nick, message) => {
-  if (nick === client.currentNick) {
-    if (message.prefix) {
-      client.currentPrefix = message.prefix;
-    }
-  }
-});
-
-let didRegister = false;
-
-client.addListener('raw', (message) => {
-  if (message.command === 'NICK' && message.nick === config.nick) {
-    const changedTo = message.args[0];
-
-    client.currentNick = changedTo;
-
-    if (changedTo === config.nick) {
+    let messageObj;
+    try {
+      // eslint-disable-next-line global-require
+      const processMessage = require('./processMessage');
+      messageObj = processMessage(client, config, logs, from, to, message);
+    } catch (e) {
+      const isRoom = /^#/.test(to);
+      if (Date.now() > lastProcessMessageFail + 1000 * 60 * 60) {
+        lastProcessMessageFail = Date.now();
+        client.say(isRoom ? to : from, `Internal error while processing the message`);
+      }
       return;
     }
 
-    if (!didRegister) return;
+    plugins.run(messageObj);
+  });
+
+  client.addListener('join', (channel, nick, message) => {
+    if (nick === client.currentNick) {
+      if (message.prefix) {
+        client.currentPrefix = message.prefix;
+      }
+    }
+  });
+
+  let didRegister = false;
+
+  client.addListener('raw', (message) => {
+    if (message.command === 'NICK' && message.nick === config.nick) {
+      const changedTo = message.args[0];
+
+      client.currentNick = changedTo;
+
+      if (changedTo === config.nick) {
+        return;
+      }
+
+      if (!didRegister) return;
+
+      setTimeout(() => {
+        changeNick(client, config.nick, true);
+      }, 60e3 * 5);
+    }
+  });
+
+  client.addListener('error', (message) => {
+    console.error(`${chalk.red('IRC Error')}:`, message);
+  });
+
+  const connectStartTime = Date.now();
+  let connectFinishTime;
+  client.addListener('registered', () => {
+    connectFinishTime = Date.now();
+    const diff = connectFinishTime - connectStartTime;
+    console.log(`${logBotPrefix}: connected to ${config.server} as ${config.nick}.`);
+    console.log(`${logBotPrefix}: took ${diff}ms to connect.`);
 
     setTimeout(() => {
-      changeNick(client, config.nick, true);
-    }, 60e3 * 5);
-  }
+      didRegister = true;
+    }, 500);
+
+    if (config.password) {
+      client.say('nickserv', `IDENTIFY ${config.userName} ${config.password}`);
+      setTimeout(() => {
+        config.channels
+          .filter((x) => x.requiresAuth)
+          .forEach((c) => {
+            client.join(c.name);
+          });
+
+        client.say('nickserv', `regain ${config.nick}`);
+      }, 1000);
+    }
+  });
+  console.log(`${logBotPrefix}: Connecting to ${config.server} as ${config.nick}`);
+
+  const receivedNickListsForChannelEver = {};
+  client.addListener('names', (channel, nicks) => {
+    if (receivedNickListsForChannelEver[channel]) {
+      return;
+    }
+    receivedNickListsForChannelEver[channel] = true;
+    const diffFromConnect = Date.now() - connectFinishTime;
+    console.log(
+      `${logBotPrefix}: connected to ${channel} which has ${
+        Object.keys(nicks).length
+      } users. Took ${diffFromConnect}ms since register.`,
+    );
+  });
 });
 
-client.addListener('error', (message) => {
-  console.error(`${chalk.red('IRC Error')}:`, message);
-});
-
-const connectStartTime = Date.now();
-let connectFinishTime;
-client.addListener('registered', () => {
-  connectFinishTime = Date.now();
-  const diff = connectFinishTime - connectStartTime;
-  console.log(`${logBotPrefix}: connected to ${config.server} as ${config.nick}.`);
-  console.log(`${logBotPrefix}: took ${diff}ms to connect.`);
-
-  setTimeout(() => {
-    didRegister = true;
-  }, 500);
-
-  if (config.password) {
-    client.say('nickserv', `IDENTIFY ${config.userName} ${config.password}`);
-    setTimeout(() => {
-      config.channels
-        .filter((x) => x.requiresAuth)
-        .forEach((c) => {
-          client.join(c.name);
-        });
-
-      client.say('nickserv', `regain ${config.nick}`);
-    }, 1000);
-  }
-});
-console.log(`${logBotPrefix}: Connecting to ${config.server} as ${config.nick}`);
-
-const receivedNickListsForChannelEver = {};
-client.addListener('names', (channel, nicks) => {
-  if (receivedNickListsForChannelEver[channel]) {
-    return;
-  }
-  receivedNickListsForChannelEver[channel] = true;
-  const diffFromConnect = Date.now() - connectFinishTime;
-  console.log(
-    `${logBotPrefix}: connected to ${channel} which has ${
-      Object.keys(nicks).length
-    } users. Took ${diffFromConnect}ms since register.`,
-  );
-});
-
-if (config.verbose) {
+if (globalConfig.verbose) {
   console.log(`${logBotPrefix}: ${chalk.yellow(`Running in verbose mode.`)}`);
 }

--- a/src/bot.js
+++ b/src/bot.js
@@ -96,8 +96,9 @@ clients.forEach((client) => {
       messageObj = processMessage(client, config, logs, from, to, message);
     } catch (e) {
       const isRoom = /^#/.test(to);
-      if (Date.now() > lastProcessMessageFail + 1000 * 60 * 60) {
-        lastProcessMessageFail = Date.now();
+      const now = Date.now();
+      if (now > lastProcessMessageFail + 1000 * 60 * 60) {
+        lastProcessMessageFail = now;
         client.say(isRoom ? to : from, `Internal error while processing the message`);
       }
       return;

--- a/src/plugins/mdn/mdnPlugin.js
+++ b/src/plugins/mdn/mdnPlugin.js
@@ -38,7 +38,7 @@ function extractFromHtml(html) {
   // Note (March 2021): unclear if #wikiArticle will ever appear in the future. The following
   // can be grepped for in the logs to see if it happens in practice, and the code simplified
   // if not.
-  let $article = findFirst($('body'), 'main#content', '#wikiArticle');
+  const $article = findFirst($('body'), 'main#content', '#wikiArticle');
   if ($article.attr('id') === 'wikiArticle') {
     console.log('METRIC::MDN_WIKI_ARTICLE', new Date().toISOString());
   }

--- a/src/utils/__tests__/__snapshots__/getConfig-test.js.snap
+++ b/src/utils/__tests__/__snapshots__/getConfig-test.js.snap
@@ -2,26 +2,30 @@
 
 exports[`works 1`] = `
 Object {
-  "channels": Array [
-    Object {
-      "name": "##jellobot-test",
-    },
-  ],
-  "commandPrefix": "!",
-  "ircClientConfig": Object {
-    "channels": Array [
-      "##jellobot-test",
-    ],
-    "retryCount": 10,
-  },
-  "nick": "jellobot",
-  "password": null,
   "plugins": Object {
     "jsEval": Object {
       "timeout": 5000,
     },
   },
-  "server": "chat.freenode.net",
+  "servers": Array [
+    Object {
+      "channels": Array [
+        Object {
+          "name": "##jellobot-test",
+        },
+      ],
+      "commandPrefix": "!",
+      "ircClientConfig": Object {
+        "channels": Array [
+          "##jellobot-test",
+        ],
+        "retryCount": 10,
+      },
+      "nick": "jellobot",
+      "password": null,
+      "server": "chat.freenode.net",
+    },
+  ],
   "verbose": false,
 }
 `;

--- a/src/utils/__tests__/getConfig-test.js
+++ b/src/utils/__tests__/getConfig-test.js
@@ -4,3 +4,15 @@ it('works', () => {
   const config = processConfig({ nick: 'jellobot' });
   expect(config).toMatchSnapshot();
 });
+
+it('handles missing servers array', () => {
+  const config = processConfig({ nick: 'jellobot' });
+  expect(config.nick).toBeUndefined();
+  expect(config.servers).toMatchObject([{ nick: 'jellobot' }]);
+});
+
+it('handles servers array', () => {
+  const config = processConfig({ servers: [{ nick: 'jellobot' }] });
+  expect(config.nick).toBeUndefined();
+  expect(config.servers).toMatchObject([{ nick: 'jellobot' }]);
+});

--- a/src/utils/getConfig.js
+++ b/src/utils/getConfig.js
@@ -21,8 +21,6 @@ const defaultServer = {
 };
 
 const defaultConfig = {
-  servers: [{ ...defaultServer }],
-
   plugins: {
     jsEval: {
       timeout: 5000,


### PR DESCRIPTION
This adds support for multiple servers (so the bot can also connect to [Libera](https://libera.chat/)). Config is now a list of servers, and a shared plugin config. It at least basically works, when running it locally.

Need another pair of eyes on whether anything is/isn't shared between the connections that shouldn't/should be.

cc @ljharb @caub 

(Will fix the tests before merging)